### PR TITLE
Use workqueues for Metacontrollers.

### DIFF
--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
+)

--- a/controller/composite/metacontroller.go
+++ b/controller/composite/metacontroller.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composite
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/golang/glog"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"k8s.io/metacontroller/apis/metacontroller/v1alpha1"
+	mcinformers "k8s.io/metacontroller/client/generated/informer/externalversions"
+	mclisters "k8s.io/metacontroller/client/generated/lister/metacontroller/v1alpha1"
+	"k8s.io/metacontroller/controller/common"
+	dynamicclientset "k8s.io/metacontroller/dynamic/clientset"
+	k8s "k8s.io/metacontroller/third_party/kubernetes"
+)
+
+type Metacontroller struct {
+	dynClient  *dynamicclientset.Clientset
+	ccLister   mclisters.CompositeControllerLister
+	ccInformer cache.SharedIndexInformer
+
+	queue             workqueue.RateLimitingInterface
+	parentControllers map[string]*parentController
+
+	stopCh, doneCh chan struct{}
+}
+
+func NewMetacontroller(dynClient *dynamicclientset.Clientset, mcInformerFactory mcinformers.SharedInformerFactory) *Metacontroller {
+	mc := &Metacontroller{
+		dynClient:         dynClient,
+		ccLister:          mcInformerFactory.Metacontroller().V1alpha1().CompositeControllers().Lister(),
+		ccInformer:        mcInformerFactory.Metacontroller().V1alpha1().CompositeControllers().Informer(),
+		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CompositeController"),
+		parentControllers: make(map[string]*parentController),
+	}
+
+	mc.ccInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    mc.enqueueCompositeController,
+		UpdateFunc: mc.updateCompositeController,
+		DeleteFunc: mc.enqueueCompositeController,
+	})
+
+	return mc
+}
+
+func (mc *Metacontroller) Start() {
+	mc.stopCh = make(chan struct{})
+	mc.doneCh = make(chan struct{})
+
+	go func() {
+		defer close(mc.doneCh)
+		defer utilruntime.HandleCrash()
+
+		glog.Info("Starting CompositeController metacontroller")
+		defer glog.Info("Shutting down CompositeController metacontroller")
+
+		if !k8s.WaitForCacheSync("CompositeController", mc.stopCh, mc.ccInformer.HasSynced) {
+			return
+		}
+
+		// In the metacontroller, we are only responsible for starting/stopping
+		// the actual controllers, so a single worker should be enough.
+		for mc.processNextWorkItem() {
+		}
+	}()
+}
+
+func (mc *Metacontroller) Stop() {
+	// Stop metacontroller first so there's no more changes to controllers.
+	close(mc.stopCh)
+	mc.queue.ShutDown()
+	<-mc.doneCh
+
+	// Stop all controllers.
+	var wg sync.WaitGroup
+	for _, pc := range mc.parentControllers {
+		wg.Add(1)
+		go func(pc *parentController) {
+			defer wg.Done()
+			pc.Stop()
+		}(pc)
+	}
+	wg.Wait()
+}
+
+func (mc *Metacontroller) processNextWorkItem() bool {
+	key, quit := mc.queue.Get()
+	if quit {
+		return false
+	}
+	defer mc.queue.Done(key)
+
+	err := mc.sync(key.(string))
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to sync CompositeController %q: %v", key, err))
+		mc.queue.AddRateLimited(key)
+		return true
+	}
+
+	mc.queue.Forget(key)
+	return true
+}
+
+func (mc *Metacontroller) sync(key string) error {
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	glog.V(4).Infof("sync CompositeController %v", name)
+
+	cc, err := mc.ccLister.Get(name)
+	if apierrors.IsNotFound(err) {
+		glog.V(4).Infof("CompositeController %v has been deleted", name)
+		// Stop and remove the controller if it exists.
+		if pc, ok := mc.parentControllers[name]; ok {
+			pc.Stop()
+			delete(mc.parentControllers, name)
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return mc.syncCompositeController(cc)
+}
+
+func (mc *Metacontroller) syncCompositeController(cc *v1alpha1.CompositeController) error {
+	if pc, ok := mc.parentControllers[cc.Name]; ok {
+		// The controller was already started.
+		if apiequality.Semantic.DeepEqual(cc.Spec, pc.cc.Spec) {
+			// Nothing has changed.
+			return nil
+		}
+		// Stop and remove the controller so it can be recreated.
+		pc.Stop()
+		delete(mc.parentControllers, cc.Name)
+	}
+
+	pc, err := newParentController(mc.dynClient, cc)
+	if err != nil {
+		return err
+	}
+	pc.Start()
+	mc.parentControllers[cc.Name] = pc
+	return nil
+}
+
+func (mc *Metacontroller) enqueueCompositeController(obj interface{}) {
+	key, err := common.KeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		return
+	}
+	mc.queue.Add(key)
+}
+
+func (mc *Metacontroller) updateCompositeController(old, cur interface{}) {
+	mc.enqueueCompositeController(cur)
+}

--- a/controller/initializer/metacontroller.go
+++ b/controller/initializer/metacontroller.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/golang/glog"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"k8s.io/metacontroller/apis/metacontroller/v1alpha1"
+	mcinformers "k8s.io/metacontroller/client/generated/informer/externalversions"
+	mclisters "k8s.io/metacontroller/client/generated/lister/metacontroller/v1alpha1"
+	"k8s.io/metacontroller/controller/common"
+	dynamicclientset "k8s.io/metacontroller/dynamic/clientset"
+	k8s "k8s.io/metacontroller/third_party/kubernetes"
+)
+
+type Metacontroller struct {
+	dynClient  *dynamicclientset.Clientset
+	icLister   mclisters.InitializerControllerLister
+	icInformer cache.SharedIndexInformer
+
+	queue                  workqueue.RateLimitingInterface
+	initializerControllers map[string]*initializerController
+
+	stopCh, doneCh chan struct{}
+}
+
+func NewMetacontroller(dynClient *dynamicclientset.Clientset, mcInformerFactory mcinformers.SharedInformerFactory) *Metacontroller {
+	mc := &Metacontroller{
+		dynClient:  dynClient,
+		icLister:   mcInformerFactory.Metacontroller().V1alpha1().InitializerControllers().Lister(),
+		icInformer: mcInformerFactory.Metacontroller().V1alpha1().InitializerControllers().Informer(),
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "InitializerController"),
+		initializerControllers: make(map[string]*initializerController),
+	}
+
+	mc.icInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    mc.enqueueInitializerController,
+		UpdateFunc: mc.updateInitializerController,
+		DeleteFunc: mc.enqueueInitializerController,
+	})
+
+	return mc
+}
+
+func (mc *Metacontroller) Start() {
+	mc.stopCh = make(chan struct{})
+	mc.doneCh = make(chan struct{})
+
+	go func() {
+		defer close(mc.doneCh)
+		defer utilruntime.HandleCrash()
+
+		glog.Info("Starting InitializerController metacontroller")
+		defer glog.Info("Shutting down InitializerController metacontroller")
+
+		if !k8s.WaitForCacheSync("InitializerController", mc.stopCh, mc.icInformer.HasSynced) {
+			return
+		}
+
+		// In the metacontroller, we are only responsible for starting/stopping
+		// the actual controllers, so a single worker should be enough.
+		for mc.processNextWorkItem() {
+		}
+	}()
+}
+
+func (mc *Metacontroller) Stop() {
+	// Stop metacontroller first so there's no more changes to controllers.
+	close(mc.stopCh)
+	mc.queue.ShutDown()
+	<-mc.doneCh
+
+	// Stop all controllers.
+	var wg sync.WaitGroup
+	for _, c := range mc.initializerControllers {
+		wg.Add(1)
+		go func(c *initializerController) {
+			defer wg.Done()
+			c.Stop()
+		}(c)
+	}
+	wg.Wait()
+}
+
+func (mc *Metacontroller) processNextWorkItem() bool {
+	key, quit := mc.queue.Get()
+	if quit {
+		return false
+	}
+	defer mc.queue.Done(key)
+
+	err := mc.sync(key.(string))
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to sync InitializerController %q: %v", key, err))
+		mc.queue.AddRateLimited(key)
+		return true
+	}
+
+	mc.queue.Forget(key)
+	return true
+}
+
+func (mc *Metacontroller) sync(key string) error {
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	glog.V(4).Infof("sync InitializerController %v", name)
+
+	cc, err := mc.icLister.Get(name)
+	if apierrors.IsNotFound(err) {
+		glog.V(4).Infof("InitializerController %v has been deleted", name)
+		// Stop and remove the controller if it exists.
+		if c, ok := mc.initializerControllers[name]; ok {
+			c.Stop()
+			delete(mc.initializerControllers, name)
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return mc.syncInitializerController(cc)
+}
+
+func (mc *Metacontroller) syncInitializerController(ic *v1alpha1.InitializerController) error {
+	if c, ok := mc.initializerControllers[ic.Name]; ok {
+		// The controller was already started.
+		if apiequality.Semantic.DeepEqual(ic.Spec, c.ic.Spec) {
+			// Nothing has changed.
+			return nil
+		}
+		// Stop and remove the controller so it can be recreated.
+		c.Stop()
+		delete(mc.initializerControllers, ic.Name)
+	}
+
+	c, err := newInitializerController(mc.dynClient, ic)
+	if err != nil {
+		return err
+	}
+	c.Start()
+	mc.initializerControllers[ic.Name] = c
+	return nil
+}
+
+func (mc *Metacontroller) enqueueInitializerController(obj interface{}) {
+	key, err := common.KeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		return
+	}
+	mc.queue.Add(key)
+}
+
+func (mc *Metacontroller) updateInitializerController(old, cur interface{}) {
+	mc.enqueueInitializerController(cur)
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -27,11 +28,10 @@ import (
 
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/metacontroller/apis/metacontroller/v1alpha1"
-	internalclient "k8s.io/metacontroller/client/generated/clientset/internalclientset"
-	internalinformers "k8s.io/metacontroller/client/generated/informer/externalversions"
+	mcclientset "k8s.io/metacontroller/client/generated/clientset/internalclientset"
+	mcinformers "k8s.io/metacontroller/client/generated/informer/externalversions"
 	"k8s.io/metacontroller/controller/composite"
 	"k8s.io/metacontroller/controller/initializer"
 	dynamicclientset "k8s.io/metacontroller/dynamic/clientset"
@@ -43,42 +43,9 @@ var (
 	informerResync    = flag.Duration("informer-resync", 5*time.Minute, "Default resync period for shared informer caches")
 )
 
-func startResyncLoop(dynClient *dynamicclientset.Clientset, mcInformerFactory internalinformers.SharedInformerFactory) (cancel func()) {
-	stop := make(chan struct{})
-	done := make(chan struct{})
-
-	ccLister := mcInformerFactory.Metacontroller().V1alpha1().CompositeControllers().Lister()
-	icLister := mcInformerFactory.Metacontroller().V1alpha1().InitializerControllers().Lister()
-
-	go func() {
-		defer close(done)
-
-		// This interval isn't configurable because polling is going away soon.
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-				// Sync all CompositeController objects.
-				if err := composite.SyncAll(dynClient, ccLister); err != nil {
-					glog.Errorf("can't sync CompositeControllers: %v", err)
-				}
-
-				// Sync all InitializerController objects.
-				if err := initializer.SyncAll(dynClient, icLister); err != nil {
-					glog.Errorf("can't sync InitializerControllers: %v", err)
-				}
-			}
-		}
-	}()
-
-	return func() {
-		close(stop)
-		<-done
-	}
+type controller interface {
+	Start()
+	Stop()
 }
 
 func main() {
@@ -92,43 +59,48 @@ func main() {
 	// Periodically refresh discovery to pick up newly-installed resources.
 	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
 	resources := dynamicdiscovery.NewResourceMap(dc)
-	stopDiscoveryRefresh := resources.Start(*discoveryInterval)
-	defer stopDiscoveryRefresh()
+	// We don't care about stopping this cleanly since it has no external effects.
+	resources.Start(*discoveryInterval)
 
 	// Create informerfactory for metacontroller api objects.
-	mcClient, err := internalclient.NewForConfig(config)
+	mcClient, err := mcclientset.NewForConfig(config)
 	if err != nil {
 		glog.Fatalf("Can't create client for api %s: %v", v1alpha1.SchemeGroupVersion, err)
 	}
-	mcInformerFactory := internalinformers.NewSharedInformerFactory(mcClient, *informerResync)
-
-	// Initialize informers.
-	mcInformerFactory.Metacontroller().V1alpha1().CompositeControllers().Informer()
-	mcInformerFactory.Metacontroller().V1alpha1().InitializerControllers().Informer()
-	mcInformerFactory.Start(nil)
-
-	// Wait for the caches to be synced before starting the loop.
-	glog.V(2).Info("Waiting for discovery and informer caches to sync")
-	if ok := cache.WaitForCacheSync(nil,
-		resources.HasSynced,
-		mcInformerFactory.Metacontroller().V1alpha1().CompositeControllers().Informer().HasSynced,
-		mcInformerFactory.Metacontroller().V1alpha1().InitializerControllers().Informer().HasSynced,
-	); !ok {
-		glog.Fatal("Failed to wait for caches to sync")
-	}
-	glog.V(2).Info("Discovery and informer caches synced")
+	mcInformerFactory := mcinformers.NewSharedInformerFactory(mcClient, *informerResync)
 
 	// Create dynamic clientset (factory for dynamic clients).
 	dynClient := dynamicclientset.New(config, resources)
 
-	// Start polling in the background.
-	// TODO(kube-metacontroller#8): Replace with shared, dynamic informers.
-	stopResyncLoop := startResyncLoop(dynClient, mcInformerFactory)
-	defer stopResyncLoop()
+	// Start metacontrollers (controllers that spawn controllers).
+	// Each one requests the informers it needs from the factory.
+	controllers := []controller{
+		composite.NewMetacontroller(dynClient, mcInformerFactory),
+		initializer.NewMetacontroller(dynClient, mcInformerFactory),
+	}
 
-	// On SIGTERM, execute deferred functions to shut down gracefully.
+	// Start all requested informers.
+	// We don't care about stopping this cleanly since it has no external effects.
+	mcInformerFactory.Start(nil)
+
+	// Start all controllers.
+	for _, c := range controllers {
+		c.Start()
+	}
+
+	// On SIGTERM, stop all controllers gracefully.
 	sigchan := make(chan os.Signal, 2)
 	signal.Notify(sigchan, os.Interrupt, syscall.SIGTERM)
 	sig := <-sigchan
 	glog.Infof("Received %q signal. Shutting down...", sig)
+
+	var wg sync.WaitGroup
+	for _, c := range controllers {
+		wg.Add(1)
+		go func(c controller) {
+			defer wg.Done()
+			c.Stop()
+		}(c)
+	}
+	wg.Wait()
 }

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -55,3 +55,5 @@ spec:
         command: ["/usr/bin/metacontroller"]
         args:
         - --logtostderr
+        - -v=5
+        - --discovery-interval=10s

--- a/third_party/kubernetes/controller.go
+++ b/third_party/kubernetes/controller.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+// This is copied from k8s.io/kubernetes to avoid a dependency on all of Kubernetes.
+// TODO(enisoc): Move the upstream code to somewhere better.
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// WaitForCacheSync is a wrapper around cache.WaitForCacheSync that generates log messages
+// indicating that the controller identified by controllerName is waiting for syncs, followed by
+// either a successful or failed sync.
+func WaitForCacheSync(controllerName string, stopCh <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool {
+	glog.Infof("Waiting for caches to sync for %s controller", controllerName)
+
+	if !cache.WaitForCacheSync(stopCh, cacheSyncs...) {
+		utilruntime.HandleError(fmt.Errorf("Unable to sync caches for %s controller", controllerName))
+		return false
+	}
+
+	glog.Infof("Caches are synced for %s controller", controllerName)
+	return true
+}


### PR DESCRIPTION
This splits the implementation for each Metacontroller API into two parts: (1) a metacontroller that spawns controllers of a given type, and (2) a controller that executes behavior on behalf of users.

The metacontrollers now use informers and workqueues, but the controllers still use polling for now.