### PR TITLE
Fix link to markdown file

### DIFF
--- a/docs/_guide/best-practices.md
+++ b/docs/_guide/best-practices.md
@@ -4,7 +4,7 @@ title: Best Practices
 This is a collection of recommendations for writing controllers with Metacontroller.
 
 If you have something to add to the collection, please send a pull request against
-[this document]({{ site.repo_file }}/docs/guide/best-practices.md).
+[this document]({{ site.repo_file }}/docs/_guide/best-practices.md).
 
 ## Lambda Hooks
 


### PR DESCRIPTION
The link at https://metacontroller.app/guide/best-practices/ for submitting changes to the best practices document is broken. Updating with its actual location (`_guide` instead of `guide`).